### PR TITLE
 (Feat) query-associations

### DIFF
--- a/src/routes/albums.js
+++ b/src/routes/albums.js
@@ -35,7 +35,7 @@ router.get('albums.list', '/', async (ctx) => {
 
 router.get('albums.show', '/:id', async (ctx) => {
   const { album } = ctx.state;
-  const artist = album.getArtist(); // lazy loading example
+  const artist = await album.getArtist(); // lazy loading example
   await ctx.render('albums/show', {
     album,
     artist,

--- a/src/routes/albums.js
+++ b/src/routes/albums.js
@@ -35,8 +35,10 @@ router.get('albums.list', '/', async (ctx) => {
 
 router.get('albums.show', '/:id', async (ctx) => {
   const { album } = ctx.state;
+  const artist = album.getArtist(); // lazy loading example
   await ctx.render('albums/show', {
     album,
+    artist,
     albumsPath: ctx.router.url('albums.list'),
   });
 });

--- a/src/routes/artists.js
+++ b/src/routes/artists.js
@@ -33,7 +33,9 @@ router.post('artists.create', '/', async (ctx) => {
 });
 
 router.get('artists.list', '/', async (ctx) => {
-  const artists = await ctx.orm.artist.findAll();
+  // const artists = await ctx.orm.artist.findAll(); \\ CAPSULA QUERIES: EJEMPLO N+1
+  // const albums = await Promise.all(artists.map((artist) => artist.getAlbums())); CAPSULA QUERIES: EJEMPLO N+1
+  const artists = await ctx.orm.artist.findAll({ include: ctx.orm.album }); // eager loading
   await ctx.render('artists/index', {
     artists,
     artistPath: (id) => ctx.router.url('artists.show', { id }),
@@ -43,11 +45,11 @@ router.get('artists.list', '/', async (ctx) => {
 
 router.get('artists.show', '/:id', async (ctx) => {
   const { artist } = ctx.state;
-  const albumList = await ctx.orm.album.findAll({where: {artistId: artist.id}})
+  const albums = await artist.getAlbums(); // lazy loading
   await ctx.render('artists/show', {
     artist,
     artistsPath: ctx.router.url('artists.list'),
-    albumList,
+    albums,
   });
 });
 

--- a/src/views/albums/show.html.ejs
+++ b/src/views/albums/show.html.ejs
@@ -1,6 +1,5 @@
 <a href="<%= albumsPath %>">Back</a>
 <h2><%= album.name %></h2>
-<h3>Artist: <%= album.artistId %></h3>
 <h3>PublishedAt: <%= album.publishedAt %></h3>
 <h3>Cover: <%= album.cover %></h3>
-
+<h3>Artist: <%= artist.name %></h3>

--- a/src/views/artists/index.html.ejs
+++ b/src/views/artists/index.html.ejs
@@ -8,6 +8,7 @@
       <th>Genres</th>
       <th>Formed At</th>
       <th>Members</th>
+      <th>Albúm 1</th>
       <th></th>
     </tr>
     <tbody>
@@ -18,6 +19,10 @@
           <td><%= artist.genres %></td>
           <td><%= artist.formedAt %></td>
           <td><%= artist.members %></td>
+          <% if (artist.albums[0] != undefined) { %>
+          <td><%= artist.albums[0].name %></td>
+          <% } else { %>
+          <td> None <% } %> </td>
           <td><a href="<%= artistPath(artist.id) %>">View more</a></td>
         </tr>
       <% }) %>

--- a/src/views/artists/index.html.ejs
+++ b/src/views/artists/index.html.ejs
@@ -19,10 +19,11 @@
           <td><%= artist.genres %></td>
           <td><%= artist.formedAt %></td>
           <td><%= artist.members %></td>
-          <% if (artist.albums[0] != undefined) { %>
-          <td><%= artist.albums[0].name %></td>
+          <% if (artist.albums.length) { %>
+            <td><%= artist.albums[0].name%></td>
           <% } else { %>
-          <td> None <% } %> </td>
+            <td> No albums </td>
+          <% } %>
           <td><a href="<%= artistPath(artist.id) %>">View more</a></td>
         </tr>
       <% }) %>

--- a/src/views/artists/show.html.ejs
+++ b/src/views/artists/show.html.ejs
@@ -1,16 +1,15 @@
 <a href="<%= artistsPath %>">Back</a>
-<h2><%= artist.name %></h2>
+<h2>Artist: <%=artist.name %></h2>
 <h3>Origin: <%= artist.origin %></h3>
 <h3>Genres: <%= artist.genres %></h3>
 <h3>Formed at: <%= artist.formedAt %></h3>
 <% if (artist.members) { %>
 <h3>Members: <%= artist.members %></h3>
 <% } %>
-
 <h3>Albums</h3>
 
 
-<% albumList.forEach((album) => { %>
+<% albums.forEach((album) => { %>
     <li>
       <td><%= album.name %></td>
     </li>


### PR DESCRIPTION
Arregle el problema de los archivos mezclados
Incluyo ejemplos de lazy loading como de eager loading, mostrando un ejemplo de n+1 en la view de artist index, y como se puede arreglar con eager loading
Hay dos ejemplos de lazy loading, uno correspondiente a `belongs to` y el otro a `has_many`
En la view de `artist index` hice ese bloque condicional para que no se cayera la página si se crea un artista que no tiene un albúm creado