### PR TITLE
Feat: artists and albums seeds

### DIFF
--- a/src/assets/styles/artists.scss
+++ b/src/assets/styles/artists.scss
@@ -1,0 +1,14 @@
+.albums {
+  display: flex;
+  flex-wrap: wrap;
+  list-style-type: none;
+  
+  li {
+    flex: 1 1 243px;
+  }
+
+  img {
+    width: auto;
+    height: 200px;
+  }
+}

--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -1,3 +1,4 @@
 @import './variables';
 @import './layout';
 @import './static';
+@import './artists';

--- a/src/migrations/20211004133253-add-reference-to-album.js
+++ b/src/migrations/20211004133253-add-reference-to-album.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addConstraint('albums', {
+      fields: ['artistId'],
+      type: 'foreign key',
+      name: 'albums_artistId_fkey',
+      references: {
+        table: 'artists',
+        field: 'id',
+      },
+      onDelete: 'CASCADE',
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeConstraint('albums', 'albums_artistId_fkey');
+  }
+};

--- a/src/seeds/20210929182049-add-user.js
+++ b/src/seeds/20210929182049-add-user.js
@@ -1,30 +1,33 @@
 const faker = require('faker');
 
-let usersArray = [];
-
-usersArray.push({
-  firstName: 'Tony',
-  lastName: 'Montana',
-  email: 'scarface@web.cl',
-  password: '123456',
-  createdAt: new Date(),
-  updatedAt: new Date(),
-});
-
-usersArray = usersArray.concat(
-  [...Array(10)].map(() => (
-    {
-      firstName: faker.name.firstName(),
-      lastName: faker.name.lastName(),
-      email: faker.internet.email(),
-      password: faker.internet.password(8),
-      createdAt: new Date(),
-      updatedAt: new Date()
-    }
-  ))
-)
-
 module.exports = {
-  up: async (queryInterface) => queryInterface.bulkInsert('users', usersArray),
-  down: async (queryInterface) => queryInterface.bulkDelete('users', null, {}),
+  up: async (queryInterface) => {
+    let usersArray = [];
+
+    usersArray.push({
+      firstName: 'Tony',
+      lastName: 'Montana',
+      email: 'scarface@web.cl',
+      password: '123456',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    usersArray = usersArray.concat(
+      [...Array(10)].map(() => (
+        {
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: faker.internet.password(8),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      ))
+    );
+
+    await queryInterface.bulkInsert('users', usersArray);
+  },
+
+  down: (queryInterface) => queryInterface.bulkDelete('users', null),
 };

--- a/src/seeds/20210930141044-add-artists.js
+++ b/src/seeds/20210930141044-add-artists.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    const artistsArray = [];
+
+    const commonData = {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    
+    artistsArray.push({
+      name: 'Tame Impala',
+      origin: 'Perth, Australia',
+      genres: 'Psychedelic pop, psychedelic rock, disco, synth-pop, neo-psychedelia',
+      formedAt: 2007,
+      members: 'Kevin Parker',
+      ...commonData,
+    });
+    
+    artistsArray.push({
+      name: 'Khruangbin',
+      origin: 'Houston, Texas, United States',
+      genres: 'Psychedelic rock, surf rock, funk, instrumental rock, dub, rock',
+      formedAt: 2009,
+      members: 'Laura Lee, Mark Speer, Donald "DJ" Johnson',
+      ...commonData,
+    });
+
+    await queryInterface.bulkInsert('artists', artistsArray);
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.bulkDelete('artists', null);
+  }
+};

--- a/src/seeds/20210930141044-add-artists.js
+++ b/src/seeds/20210930141044-add-artists.js
@@ -30,7 +30,5 @@ module.exports = {
     await queryInterface.bulkInsert('artists', artistsArray);
   },
 
-  down: async (queryInterface) => {
-    await queryInterface.bulkDelete('artists', null);
-  }
+  down: (queryInterface) => queryInterface.bulkDelete('artists', null),
 };

--- a/src/seeds/20211004142403-add-albums.js
+++ b/src/seeds/20211004142403-add-albums.js
@@ -85,7 +85,5 @@ module.exports = {
     );
   },
 
-  down: async (queryInterface) => {
-    await queryInterface.bulkDelete('albums', null);
-  }
+  down: (queryInterface) => queryInterface.bulkDelete('albums', null),
 };

--- a/src/seeds/20211004142403-add-albums.js
+++ b/src/seeds/20211004142403-add-albums.js
@@ -1,0 +1,91 @@
+const { QueryTypes } = require('sequelize');
+
+module.exports = {
+  up: async (queryInterface) => {
+    const albumsArray = [];
+
+    const commonData = {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    async function findArtistIdByName(name) {
+      const artists = await queryInterface.sequelize.query(
+        'SELECT "id" FROM "artists" WHERE "artists"."name" = ?',
+        {
+          replacements: [name],
+          type: QueryTypes.SELECT,
+        },
+      );
+
+      const [artistId] = artists.map(({ id }) => id);
+      return artistId;
+    }
+
+    let artistId = await findArtistIdByName('Tame Impala');
+
+    if (artistId) {
+      albumsArray.push({
+        name: 'InnerSpeaker',
+        publishedAt: '2010-05-21',
+        cover: 'https://img.discogs.com/vXs09GMxHzOugRyYyN2M-P_p3WI=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-2402720-1547448092-2132.jpeg.jpg',
+        artistId,
+      });
+
+      albumsArray.push({
+        name: 'Lonerism',
+        publishedAt: '2012-10-05',
+        cover: 'https://img.discogs.com/TQGqHoBO0Zd0DdMXKhl73weJdRM=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-6281154-1415488872-1632.jpeg.jpg',
+        artistId,
+      });
+
+      albumsArray.push({
+        name: 'Currents',
+        publishedAt: '2015-07-17',
+        cover: 'https://img.discogs.com/TH3722IESsHH9YyVXkLFhgTRDyA=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-7268943-1437635726-4759.jpeg.jpg',
+        artistId,
+      });
+
+      albumsArray.push({
+        name: 'The Slow Rush',
+        publishedAt: '2020-02-14',
+        cover: 'https://img.discogs.com/S5KrNXLXyvdAML-w_2vmHftW914=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-14783822-1581621221-8754.jpeg.jpg',
+        artistId,
+      });
+    }
+
+    artistId = await findArtistIdByName('Khruangbin');
+
+    if (artistId) {
+      albumsArray.push({
+        name: 'The Universe Smiles upon You',
+        publishedAt: '2015-11-06',
+        cover: 'https://img.discogs.com/hrGokqg3_m8ACG94kAUFtCsZiCc=/fit-in/500x500/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-7695323-1446910832-1238.jpeg.jpg',
+        artistId,
+      });
+
+      albumsArray.push({
+        name: 'Con Todo el Mundo',
+        publishedAt: '2018-01-26',
+        cover: 'https://img.discogs.com/ad9oJYgp7Usrr9Lmax6U4CGEwgc=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-13090298-1547893744-2223.jpeg.jpg',
+        artistId,
+      });
+
+      albumsArray.push({
+        name: 'Mordechai',
+        publishedAt: '2020-06-26',
+        cover: 'https://img.discogs.com/OX26JtPyot0RdcNDxbBdHBsJCXY=/fit-in/600x590/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-15511221-1593462255-4290.jpeg.jpg',
+        artistId,
+      });
+    }
+
+    await queryInterface.bulkInsert(
+      'albums',
+      albumsArray.map((album) => ({ ...album, ...commonData })),
+    );
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.bulkDelete('albums', null);
+  }
+};

--- a/src/views/artists/show.html.ejs
+++ b/src/views/artists/show.html.ejs
@@ -8,9 +8,11 @@
 <% } %>
 <h3>Albums</h3>
 
-
-<% albums.forEach((album) => { %>
+<ul class="albums">
+  <% albums.forEach((album) => { %>
     <li>
-      <td><%= album.name %></td>
+      <h4><%= album.name %></h4>
+      <img src="<%= album.cover %>" alt="<%= album.name %>, album from <%= artist.name %>" />
     </li>
-    <% }) %>
+  <% }) %>
+</ul>


### PR DESCRIPTION
# Funcionalidades

Este PR agrega lo siguiente:
- Seeds para `artists` y `albums`
- Una migración que le agrega un foreign key constraint a la tabla `albums`, asociado al campo `artistId`, que ahora hace referencia a la tabla `artists`. Además se incluye la estrategia `CASCADE` al eliminarse un registro de la tabla `artists`
- Una actualización de la vista de detalle de un artista, para mostrar el cover de los álbumes asociados

# Screenshots
<img width="1229" alt="Screen Shot 2021-10-04 at 17 24 22" src="https://user-images.githubusercontent.com/421739/135878985-a857e335-f09f-4fcc-8108-57f32028bea2.png">