### PR TITLE
Feat/mailer

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "webpack-manifest-plugin": "^2.2.0"
   },
   "dependencies": {
+    "@sendgrid/mail": "^7.5.0",
     "bcrypt": "^5.0.1",
     "core-js": "^3.6.5",
     "dotenv": "^10.0.0",

--- a/src/mailers/registration.js
+++ b/src/mailers/registration.js
@@ -2,13 +2,17 @@ require('dotenv').config();
 
 module.exports = function registrationEmail(firstName, lastName, email) {
   return {
-    to: email,
     from: process.env.SENDGRID_EMAIL,
-    subject: 'Registration successful',
-    html: `
-      <h1>Welcome ${firstName} ${lastName}!</h1>
-      <p>You success create account on email ${email}</p>
-      <hr />
-    `,
+    personalizations: [{
+      to: {
+        email,
+      },
+      dynamic_template_data: {
+        first_name: firstName,
+        last_name: lastName,
+        subject: 'Registration successful',
+      },
+    }],
+    template_id: process.env.SENDGRID_NEW_USER,
   };
 };

--- a/src/mailers/registration.js
+++ b/src/mailers/registration.js
@@ -1,7 +1,8 @@
-require('dotenv').config();
+const sendgridMail = require('./sendgrid');
 
-module.exports = function registrationEmail(firstName, lastName, email) {
-  return {
+module.exports = function sendRegistrationEmail(user) {
+  const { firstName, lastName, email } = user;
+  const emailData = {
     from: process.env.SENDGRID_EMAIL,
     personalizations: [{
       to: {
@@ -15,4 +16,6 @@ module.exports = function registrationEmail(firstName, lastName, email) {
     }],
     template_id: process.env.SENDGRID_NEW_USER,
   };
+
+  return sendgridMail.send(emailData);
 };

--- a/src/mailers/registration.js
+++ b/src/mailers/registration.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const sendgridMail = require('./sendgrid');
 
 module.exports = function sendRegistrationEmail(user) {

--- a/src/mailers/registration.js
+++ b/src/mailers/registration.js
@@ -1,0 +1,14 @@
+require('dotenv').config();
+
+module.exports = function registrationEmail(firstName, lastName, email) {
+  return {
+    to: email,
+    from: process.env.SENDGRID_EMAIL,
+    subject: 'Registration successful',
+    html: `
+      <h1>Welcome ${firstName} ${lastName}!</h1>
+      <p>You success create account on email ${email}</p>
+      <hr />
+    `,
+  };
+};

--- a/src/mailers/sendgrid.js
+++ b/src/mailers/sendgrid.js
@@ -1,0 +1,7 @@
+require('dotenv').config();
+
+const sendgridMail = require('@sendgrid/mail');
+
+sendgridMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+module.exports = sendgridMail;

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,7 @@ const artists = require('./routes/artists');
 const albums = require('./routes/albums');
 const albumsForArtists = require('./routes/albumsForArtists');
 const users = require('./routes/users');
+const usersApi = require('./routes/api/users');
 const session = require('./routes/session');
 
 const router = new KoaRouter();
@@ -52,5 +53,6 @@ router.use('/albums', albums.routes());
 router.use('/artists/:artistId/albums', albumsForArtists.routes());
 router.use('/users', users.routes());
 router.use('/session', session.routes());
+router.use('/api/users', usersApi.routes());
 
 module.exports = router;

--- a/src/routes/api/users.js
+++ b/src/routes/api/users.js
@@ -1,0 +1,26 @@
+const KoaRouter = require('koa-router');
+const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const registrationEmail = require('../../mailers/registration');
+const sendgridMail = require('../../mailers/sendgrid');
+
+const UserSerializer = new JSONAPISerializer('users', {
+  attributes: ['firstName', 'lastName', 'email'],
+  keyForAttribute: 'camelCase',
+});
+
+const router = new KoaRouter();
+
+router.post('users.api.create', '/', async (ctx) => {
+  const { firstName, lastName, email } = ctx.request.body;
+  const user = ctx.orm.user.build(ctx.request.body);
+  try {
+    await user.save({ fields: ['firstName', 'lastName', 'email', 'password'] });
+    await sendgridMail.send(registrationEmail(firstName, lastName, email));
+    ctx.body = UserSerializer.serialize(user);
+    ctx.status = 201;
+  } catch (ValidationError) {
+    ctx.throw(400);
+  }
+});
+
+module.exports = router;

--- a/src/routes/api/users.js
+++ b/src/routes/api/users.js
@@ -1,7 +1,6 @@
 const KoaRouter = require('koa-router');
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
-const registrationEmail = require('../../mailers/registration');
-const sendgridMail = require('../../mailers/sendgrid');
+const sendRegistrationEmail = require('../../mailers/registration');
 
 const UserSerializer = new JSONAPISerializer('users', {
   attributes: ['firstName', 'lastName', 'email'],
@@ -11,11 +10,10 @@ const UserSerializer = new JSONAPISerializer('users', {
 const router = new KoaRouter();
 
 router.post('users.api.create', '/', async (ctx) => {
-  const { firstName, lastName, email } = ctx.request.body;
   const user = ctx.orm.user.build(ctx.request.body);
   try {
     await user.save({ fields: ['firstName', 'lastName', 'email', 'password'] });
-    await sendgridMail.send(registrationEmail(firstName, lastName, email));
+    await sendRegistrationEmail(user);
     ctx.body = UserSerializer.serialize(user);
     ctx.status = 201;
   } catch (ValidationError) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,29 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@sendgrid/client@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.5.0.tgz#f22e083f6d457aed392a5e44f055ae3a378b2449"
+  integrity sha512-tu2l3a1Egp65hRsDdX6qUHvpZydZvgEL7PLViQh4uu5DTqztpNCyw0UQYkyPYyXInWJjLax12UOciTG2V/s4OQ==
+  dependencies:
+    "@sendgrid/helpers" "^7.5.0"
+    axios "^0.21.4"
+
+"@sendgrid/helpers@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.5.0.tgz#1459915f740266b1741687333380a7434860541c"
+  integrity sha512-uzCzpougTDKifyVksx5obZtMcEypq7UVAon/FLurrGEncGrx/N4bYDGPo4chmEdHAZvN75fpavyfETx3DZYebg==
+  dependencies:
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.5.0.tgz#adcd3a1b1153108866a26edff80c3658e576a0db"
+  integrity sha512-/JEQJagigZreHsApOdFdZC2ZtSwaQY5Kvjj29a3BUrx8bEX0bQUlBjlIVQkrxpkgzTvTQgR3kaRzX6BoLiS44A==
+  dependencies:
+    "@sendgrid/client" "^7.5.0"
+    "@sendgrid/helpers" "^7.5.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -2001,6 +2024,13 @@ axe-core@^3.5.4:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
+
+axios@^0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
 
 axobject-query@^2.1.2:
   version "2.2.0"
@@ -4133,6 +4163,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+follow-redirects@^1.14.0:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -5893,11 +5928,6 @@ jws@^3.2.2:
   dependencies:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
-
-jwtoken@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jwtoken/-/jwtoken-0.0.0.tgz#dd070385e0b4dfde4f95e0243e633250615116a4"
-  integrity sha512-ksJY5AC2eo7FJ6HSpB6dacZI38njm46m0W13hzt1EojRtL5eXwdf/e8NHP81brPkczspmMCucpRjzBjN/J9DXw==
 
 keygrip@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Description

- Added support for `@sendgrid/mail`, every time a user registers, an email is sent to the email the user used for registration.
- The emails are created using dynamic templates from Sendgrid

## Requirements

Add the following to `.env` file:

- SENDGRID_API_KEY: The api key generated at the Sendgrid website.
- SENDGRID_EMAIL: The email used in Single Sender Verification.
- SENDGRID_NEW_USER: The Dynamic Template id

## Additional changes

- Created `/api/users` endpoint, to use it for user registration

Made by @LeoMo-27 with help of @valeeeriquelme 